### PR TITLE
feature/142/delete-indices

### DIFF
--- a/public/pages/Indices/containers/Indices/Indices.tsx
+++ b/public/pages/Indices/containers/Indices/Indices.tsx
@@ -24,6 +24,7 @@ import {
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import IndexControls from "../../components/IndexControls";
 import ApplyPolicyModal from "../../components/ApplyPolicyModal";
+import ConfirmationModal from "../../../../components/ConfirmationModal";
 import IndexEmptyPrompt from "../../components/IndexEmptyPrompt";
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS, indicesColumns } from "../../utils/constants";
 import { ModalConsumer } from "../../../../components/Modal";
@@ -169,6 +170,32 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
     this.setState({ from: 0, search: queryText, query });
   };
 
+  onClickDeleteIndices = async (indices: string[]): Promise<void> => {
+    console.log("test");
+    // try {
+    //   if (!indices.length) return;
+    //   const { managedIndexService } = this.props;
+    //   const removePolicyResponse = await managedIndexService.removePolicy(indices);
+    //   if (removePolicyResponse.ok) {
+    //     const { updatedIndices, failedIndices, failures } = removePolicyResponse.response;
+    //     if (updatedIndices) {
+    //       this.context.notifications.toasts.addSuccess(`Removed policy from ${updatedIndices} managed indices`);
+    //     }
+    //     if (failures) {
+    //       this.context.notifications.toasts.addDanger(
+    //         `Failed to remove policy from ${failedIndices
+    //           .map((failedIndex) => `[${failedIndex.indexName}, ${failedIndex.reason}]`)
+    //           .join(", ")}`
+    //       );
+    //     }
+    //   } else {
+    //     this.context.notifications.toasts.addDanger(removePolicyResponse.error);
+    //   }
+    // } catch (err) {
+    //   this.context.notifications.toasts.addDanger(getErrorMessage(err, "There was a problem removing the policies"));
+    // }
+  };
+
   resetFilters = (): void => {
     this.setState({ search: DEFAULT_QUERY_PARAMS.search, query: Query.parse(DEFAULT_QUERY_PARAMS.search) });
   };
@@ -215,6 +242,21 @@ export default class Indices extends Component<IndicesProps, IndicesState> {
             {({ onShow }) => (
               <ContentPanelActions
                 actions={[
+                  {
+                    text: "Delete",
+                    buttonProps: {
+                      disabled: !selectedItems.length,
+                      onClick: () =>
+                        onShow(ConfirmationModal, {
+                          title: `Delete ${selectedItems.length === 1 ? selectedItems[0].index : `${selectedItems.length} indices`}`,
+                          bodyMessage: `Delete ${
+                            selectedItems.length === 1 ? `${selectedItems[0].index} index` : `${selectedItems.length} indices`
+                          } permanently? This action cannot be undone.`,
+                          actionMessage: "Delete",
+                          onAction: () => this.onClickDeleteIndices(selectedItems.map((item) => item.index)),
+                        }),
+                    },
+                  },
                   {
                     text: "Apply policy",
                     buttonProps: {


### PR DESCRIPTION
### Description
Adds a delete button to the Indices page, allowing users to delete one or more indices.

### Issues Resolved
index-management-dashboards-plugin/issues/142

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
